### PR TITLE
Use different level of depth 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Why version 2?
 A use case explaining the differences between the 2 versions may help
 ```
 tests/
-   - 100_UI_testing/
+   - UI_testing/
          - Login.robot
          - Checkout.robot
-   - 200_API_testing/
-         - 201_Catalog/
+   - API_testing/
+         - Catalog/
             - Catalog.robot
             - Categories.robot
             - Images.robot

--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ How to use SplitSuite_v2.py?
 
 ```
 bd@testing:~/robot$ robot --dryrun --prerunmodifier SplitSuite.py:3:1:4 tests/
-where:
-- 3: the number of desired splits
-- 1: the specific split (out of 3) to run now
-- 4: max depth level of the "test/" directory the splitter must go through before performing the split
 ```
 This script takes three arguments, “number of groups”, which group do you want execute and the max level of depth the splitter will go through in your tests folder before performing the splitter.
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ How to use SplitSuite.py?
 
 ```
 akash@SkyFall:~/robot$ robot --dryrun --prerunmodifier SplitSuite.py:3:1 tests/
+
 Visiting SUITE: Tests
 Total number of suites: 36
 number of suites: 12.0
 Suites in this part: 12
 ...
 ```
-
-This script takes two argument, “number of groups” and which group do you want execute. 
+This script takes two arguments, “number of groups” and which group do you want execute. 
 Note that passing argument is different here, e.g “3:1”. 
 Above snippet will divide suite into 3 groups and run 1st group.
 
@@ -22,3 +22,36 @@ Now,if you want to execute 2nd group you will run
 ```
 akash@SkyFall:~/robot$ robot --dryrun --prerunmodifier SplitSuite.py:3:2 tests/
 ```
+
+How to use SplitSuite_v2.py?
+---
+
+```
+bd@testing:~/robot$ robot --dryrun --prerunmodifier SplitSuite.py:3:1:4 tests/
+where:
+- 3: the number of desired splits
+- 1: the specific split (out of 3) to run now
+- 4: max depth level of the "test/" directory the splitter must go through before performing the split
+```
+This script takes three arguments, “number of groups”, which group do you want execute and the max level of depth the splitter will go through in your tests folder before performing the splitter.
+
+Why version 2?
+---
+A use case explaining the differences between the 2 versions may help
+```
+tests/
+   - 100_UI_testing/
+         - Login.robot
+         - Checkout.robot
+   - 200_API_testing/
+         - 201_Catalog/
+            - Catalog.robot
+            - Categories.robot
+            - Images.robot
+            - Upselling.robot
+            - Prices.robot
+         - Cart.robot
+```
+In the above example, the script version 1 would bring to 2 splits, where the first one would contain Login.robot and Checkout.robot, while the second split would contain a lot more suites to run.
+
+The second version of the script lets you flatten the tree structure to a specified level. Let's say level 2. The script will take all the single .robot files and after that it will splits the suites into 2 runs.

--- a/README.md
+++ b/README.md
@@ -50,4 +50,5 @@ tests/
 ```
 In the above example, the script version 1 would bring to 2 splits, where the first one would contain Login.robot and Checkout.robot, while the second split would contain a lot more suites to run.
 
-The second version of the script lets you flatten the tree structure to a specified level. Let's say level 2. The script will take all the single .robot files and after that it will splits the suites into 2 runs.
+The second version of the script lets you flatten the tree structure to a specified level. Let's say level 2. The script will take all the single .robot files and after that it will splits the suites into 2 runs. 
+The 2 splits will have 4 suites each.

--- a/SplitSuite_v2.py
+++ b/SplitSuite_v2.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# vim: et
+# example: SplitSuite.py:3:1 => divide whole suite into 3 parts and execute 1st part
+# from parts.
+# Based on Splitter authored by: Akash Shende https://github.com/akash0x53/robot-parallel/blob/master/SplitSuite.py
+
+
+from robot.api import SuiteVisitor
+from itertools import islice
+import math
+
+
+def chunked(lst, nchunk):
+    iter_lst = iter(lst)
+    return iter(lambda: list(islice(iter_lst, nchunk)), [])
+
+
+def fetch_subsuites(parent):
+    children = [child for child in parent.suites]
+    return children
+
+
+def fetch_suites_names(suites_list):
+    names = [s.name for s in suites_list]
+    return names
+
+
+class SplitSuite(SuiteVisitor):
+    """Visitor that keeps only every Xth test in the visited suite structure."""
+
+    def __init__(self, parts, which_part=1, max_suite_level=2):
+        self.parts = float(parts)
+        self.which_part = int(which_part)
+        self.max_suite_level = max_suite_level
+
+    def visit_suite(self, suite):
+        print("Visiting SUITE:", suite)
+        sub_suites_list = []
+        if self.max_suite_level == 1:
+            sub_suites_list = suite.suites
+        else:
+            for suite_lev_1 in suite.suites:
+                print("> Suite Lev 1: ", suite_lev_1.name)
+                next_lev_suites = fetch_subsuites(suite_lev_1)
+                for lev in range(2, self.max_suite_level+1):
+                    print(">>> Extracting suites with level: ", lev)
+                    current_lev_suites = next_lev_suites.copy()
+                    if lev == self.max_suite_level:
+                        sub_suites_list += current_lev_suites
+                        continue
+                    next_lev_suites = []
+                    for curr_lev_suite in current_lev_suites:
+                        next_lev_suites_tmp = fetch_subsuites(curr_lev_suite)
+                        if not next_lev_suites_tmp:
+                            # print("Fetching sub suites from previous level: ", str(lev-1))
+                            sub_suites_list.append(curr_lev_suite)
+                        else:
+                            next_lev_suites += next_lev_suites_tmp
+
+        print("Total number of 1st level suites:", len(suite.suites))
+        print("1st level suites:", suite.suites)
+        print("Total number of fetched suites: ", len(sub_suites_list))
+        suite_names = fetch_suites_names(sub_suites_list)
+        print("Suites names in the suite: ", suite_names)
+        num_suite = math.ceil(len(sub_suites_list) / self.parts)
+        print("Number of suites per split:", num_suite)
+        chunked_suites = [i for i in chunked(sub_suites_list, num_suite)]
+        print("Number of chunked suites: ", len(chunked_suites))
+        print("Chunked suites: ", chunked_suites)
+        suite_to_execute = chunked_suites[self.which_part - 1]
+
+        try:
+            if len(chunked_suites[self.which_part]) < num_suite and int(self.which_part) == int(self.parts):
+                suite_to_execute.extend(chunked_suites[self.which_part])
+        except IndexError:
+            pass
+
+        print("Suites in this part:", len(suite_to_execute))
+        print("Suites to be execute:", suite_to_execute)
+        suite.suites = suite_to_execute


### PR DESCRIPTION
Hello! I found very useful your work with this script, but I had to change it a bit for my needs. 

The original script splits the suites based on the first level of folders, but in my case it made the splits unbalanced. So, this PR creates a new script based on the original one, where user can select the maximum level in the directory tree. 
For example,

```
tests/
   - UI_testing/
         - Login.robot
         - Checkout.robot
   - API_testing/
         - Catalog/
            - Catalog.robot
            - Categories.robot
            - Images.robot
            - Upselling.robot
            - Prices.robot
         - Cart.robot   
```
In the above example, the original script would bring to 2 splits, where the first one would contain `Login.robot `and `Checkout.robot`, while the second split would contain a lot more suites to run.

The script version from this PR lets you flatten the tree structure to a specified level. Let's say level 2. The script will take all the single .robot files and after that it will splits the suites into 2 runs (4 suites each)

